### PR TITLE
Fix trailing slash in Glitter interface

### DIFF
--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -81,7 +81,7 @@
             </li>
             <!--#end if#-->
             <li data-tooltip="true" data-placement="bottom" title="SABnzbd $T('menu-config')">
-                <a href="config"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="config/"><span class="glyphicon glyphicon-cog"></span></a>
             </li>
             <li class="dropdown main-menu-link" data-bind="css: { 'active-on-queue-finish-menu': onQueueFinish()}">
                 <a href="#" data-toggle="dropdown"  onclick="keepOpen(this)">


### PR DESCRIPTION
The Config menu item off the main page of the the Glitter web-interface breaks when sabnzbd is accessed via a reverse-proxy (tested with pound and haproxy), because of a missing trailing slash.  This one-character change simply adds the missing slash.
